### PR TITLE
proposed changes to use more of Moo

### DIFF
--- a/lib/App/Spec.pm
+++ b/lib/App/Spec.pm
@@ -12,14 +12,14 @@ use App::Spec::Parameter;
 use YAML::XS ();
 
 use Moo;
+use Types::Standard qw(Str);
 
 with('App::Spec::Role::Command');
 
-has title => ( is => 'rw' );
-has abstract => ( is => 'rw' );
-
-
-
+has [qw(title abstract)] => (
+    is => 'rw',
+    isa => Str,
+);
 
 sub runner {
     my ($self, %args) = @_;

--- a/lib/App/Spec/Argument.pm
+++ b/lib/App/Spec/Argument.pm
@@ -6,8 +6,8 @@ package App::Spec::Argument;
 our $VERSION = '0.000'; # VERSION
 
 use Moo;
-use App::Spec::Types qw(ArgumentCompletion);
-use Types::Standard qw(Str Bool);
+use App::Spec::Types qw(ArgumentCompletion ArgumentValues);
+use Types::Standard qw(Str Bool ArrayRef);
 
 has name => (
     is => 'ro',
@@ -37,6 +37,11 @@ has completion => (
 has enum => (
     is => 'ro',
     isa => ArrayRef[Str],
+);
+
+has default => (
+    is => 'ro',
+    isa => Str,
 );
 
 has values => (

--- a/lib/App/Spec/Argument.pm
+++ b/lib/App/Spec/Argument.pm
@@ -6,7 +6,7 @@ package App::Spec::Argument;
 our $VERSION = '0.000'; # VERSION
 
 use Moo;
-use App::Spec::Types qw(SpecArgumentCompletion SpecArgumentValues);
+use App::Spec::Types qw(SpecArgumentCompletion SpecArgumentValues ArgumentType);
 use Types::Standard qw(Str Bool ArrayRef);
 
 has name => (
@@ -15,7 +15,11 @@ has name => (
     isa => Str,
 );
 
-has type => ( is => 'ro' );
+has type => (
+    is => 'ro',
+    isa => ArgumentType,
+    default => 'string',
+);
 
 has [qw(multiple mapping required unique)] => (
     is => 'ro',
@@ -26,6 +30,7 @@ has [qw(multiple mapping required unique)] => (
 has [qw(summary description)] => (
     is => 'ro',
     isa => Str,
+    default => '',
 );
 
 has completion => (
@@ -57,9 +62,6 @@ around BUILDARGS => sub {
     if (defined $args->{spec}) {
         %dsl = $class->from_dsl(delete $args->{spec});
     }
-    $args->{description} //= '';
-    $args->{summary} //= '';
-    $args->{type} //= 'string';
     @{$args}{keys %dsl} = values %dsl;
 
     not defined $args->{ $_ } and delete $args->{ $_ } for keys %{$args};

--- a/lib/App/Spec/Argument.pm
+++ b/lib/App/Spec/Argument.pm
@@ -49,35 +49,22 @@ has values => (
     isa => SpecArgumentValues,
 );
 
-sub common {
-    my ($class, %args) = @_;
+around BUILDARGS => sub {
+    my ($orig,$class,@etc) = @_;
+    my $args = $class->$orig(@etc);
+
     my %dsl;
-    if (defined $args{spec}) {
-        %dsl = $class->from_dsl(delete $args{spec});
+    if (defined $args->{spec}) {
+        %dsl = $class->from_dsl(delete $args->{spec});
     }
-    my $description = $args{description};
-    my $summary = $args{summary};
-    $summary //= '';
-    $description //= '';
-    my $type = $args{type} // 'string';
-    my %hash = (
-        name => $args{name},
-        summary => $summary,
-        description => $description,
-        type => $type,
-        multiple => $args{multiple} ? 1 : 0,
-        mapping => $args{mapping} ? 1 : 0,
-        required => $args{required} ? 1 : 0,
-        unique => $args{unique} ? 1 : 0,
-        default => $args{default},
-        completion => $args{completion},
-        enum => $args{enum},
-        values => $args{values},
-        %dsl,
-    );
-    not defined $hash{ $_ } and delete $hash{ $_ } for keys %hash;
-    return %hash;
-}
+    $args->{description} //= '';
+    $args->{summary} //= '';
+    $args->{type} //= 'string';
+    @{$args}{keys %dsl} = values %dsl;
+
+    not defined $args->{ $_ } and delete $args->{ $_ } for keys %{$args};
+    return $args;
+};
 
 my $name_re = qr{[\w-]+};
 

--- a/lib/App/Spec/Argument.pm
+++ b/lib/App/Spec/Argument.pm
@@ -6,7 +6,7 @@ package App::Spec::Argument;
 our $VERSION = '0.000'; # VERSION
 
 use Moo;
-use App::Spec::Types qw(ArgumentCompletion ArgumentValues);
+use App::Spec::Types qw(SpecArgumentCompletion SpecArgumentValues);
 use Types::Standard qw(Str Bool ArrayRef);
 
 has name => (
@@ -30,7 +30,7 @@ has [qw(summary description)] => (
 
 has completion => (
     is => 'ro',
-    isa => ArgumentCompletion,
+    isa => SpecArgumentCompletion,
     default => 0,
 );
 
@@ -46,7 +46,7 @@ has default => (
 
 has values => (
     is => 'ro',
-    isa => ArgumentValues,
+    isa => SpecArgumentValues,
 );
 
 sub common {

--- a/lib/App/Spec/Argument.pm
+++ b/lib/App/Spec/Argument.pm
@@ -6,19 +6,43 @@ package App::Spec::Argument;
 our $VERSION = '0.000'; # VERSION
 
 use Moo;
+use App::Spec::Types qw(ArgumentCompletion);
+use Types::Standard qw(Str Bool);
 
-has name => ( is => 'ro' );
+has name => (
+    is => 'ro',
+    required => 1,
+    isa => Str,
+);
+
 has type => ( is => 'ro' );
-has multiple => ( is => 'ro' );
-has mapping => ( is => 'ro' );
-has required => ( is => 'ro' );
-has unique => ( is => 'ro' );
-has summary => ( is => 'ro' );
-has description => ( is => 'ro' );
-has default => ( is => 'ro' );
-has completion => ( is => 'ro' );
-has enum => ( is => 'ro' );
-has values => ( is => 'ro' );
+
+has [qw(multiple mapping required unique)] => (
+    is => 'ro',
+    isa => Bool,
+    default => 0,
+);
+
+has [qw(summary description)] => (
+    is => 'ro',
+    isa => Str,
+);
+
+has completion => (
+    is => 'ro',
+    isa => ArgumentCompletion,
+    default => 0,
+);
+
+has enum => (
+    is => 'ro',
+    isa => ArrayRef[Str],
+);
+
+has values => (
+    is => 'ro',
+    isa => ArgumentValues,
+);
 
 sub common {
     my ($class, %args) = @_;

--- a/lib/App/Spec/Completion.pm
+++ b/lib/App/Spec/Completion.pm
@@ -6,8 +6,13 @@ package App::Spec::Completion;
 our $VERSION = '0.000'; # VERSION
 
 use Moo;
+use App::Spec::Types qw(AppSpec);
 
-has spec => ( is => 'ro' );
+has spec => (
+    is => 'ro',
+    required => 1,
+    isa => AppSpec,
+);
 
 1;
 

--- a/lib/App/Spec/Completion/Bash.pm
+++ b/lib/App/Spec/Completion/Bash.pm
@@ -359,14 +359,14 @@ sub dynamic_completion {
 
     my $def = $p->completion;
     my ($op, $command, $command_string);
-    if (not ref $def and $def == 1) {
-        my $possible_values = $p->values or die "Error for '$name': completion: 1 but 'values' not defined";
-        $op = $possible_values->{op} or die "Error for '$name': 'values' needs an 'op'";
-    }
-    elsif (ref $def) {
+    if (ref $def) {
         $op = $def->{op};
         $command = $def->{command};
         $command_string = $def->{command_string};
+    }
+    elsif ($def) {
+        my $possible_values = $p->values or die "Error for '$name': completion: 1 but 'values' not defined";
+        $op = $possible_values->{op} or die "Error for '$name': 'values' needs an 'op'";
     }
     else {
         die "Error for '$name': invalid value for 'completion'";

--- a/lib/App/Spec/Completion/Zsh.pm
+++ b/lib/App/Spec/Completion/Zsh.pm
@@ -240,14 +240,14 @@ sub dynamic_completion {
 
     my $def = $p->completion;
     my ($op, $command, $command_string);
-    if (not ref $def and $def == 1) {
-        my $possible_values = $p->values or die "Error for '$name': completion: 1 but 'values' not defined";
-        $op = $possible_values->{op} or die "Error for '$name': 'values' needs an 'op'";
-    }
-    elsif (ref $def) {
+    if (ref $def) {
         $op = $def->{op};
         $command = $def->{command};
         $command_string = $def->{command_string};
+    }
+    elsif ($def) {
+        my $possible_values = $p->values or die "Error for '$name': completion: 1 but 'values' not defined";
+        $op = $possible_values->{op} or die "Error for '$name': 'values' needs an 'op'";
     }
     else {
         die "Error for '$name': invalid value for 'completion'";

--- a/lib/App/Spec/Option.pm
+++ b/lib/App/Spec/Option.pm
@@ -5,10 +5,15 @@ package App::Spec::Option;
 
 our $VERSION = '0.000'; # VERSION
 
-use base 'App::Spec::Argument';
 use Moo;
+extends 'App::Spec::Argument';
+use Types::Standard qw(Str ArrayRef);
 
-has aliases => ( is => 'ro' );
+has aliases => (
+    is => 'ro',
+    isa => ArrayRef[Str],
+    default => sub { [] },
+);
 
 sub build {
     my ($class, %args) = @_;

--- a/lib/App/Spec/Option.pm
+++ b/lib/App/Spec/Option.pm
@@ -15,16 +15,6 @@ has aliases => (
     default => sub { [] },
 );
 
-sub build {
-    my ($class, %args) = @_;
-    my %hash = $class->common(%args);
-    my $self = $class->new({
-        aliases => $args{aliases} || [],
-        %hash,
-    });
-    return $self;
-}
-
 1;
 
 =pod

--- a/lib/App/Spec/Parameter.pm
+++ b/lib/App/Spec/Parameter.pm
@@ -5,17 +5,8 @@ package App::Spec::Parameter;
 
 our $VERSION = '0.000'; # VERSION
 
-use base 'App::Spec::Argument';
 use Moo;
-
-sub build {
-    my ($class, %args) = @_;
-    my %hash = $class->common(%args);
-    my $self = $class->new({
-        %hash,
-    });
-    return $self;
-}
+extends 'App::Spec::Argument';
 
 sub to_usage_header {
     my ($self) = @_;

--- a/lib/App/Spec/Pod.pm
+++ b/lib/App/Spec/Pod.pm
@@ -8,8 +8,13 @@ our $VERSION = '0.000'; # VERSION
 use Text::Table;
 
 use Moo;
+use App::Spec::Types qw(AppSpec);
 
-has spec => ( is => 'ro' );
+has spec => (
+    is => 'ro',
+    isa => AppSpec,
+    required => 1,
+);
 
 sub generate {
     my ($self) = @_;

--- a/lib/App/Spec/Role/Command.pm
+++ b/lib/App/Spec/Role/Command.pm
@@ -10,7 +10,7 @@ use Ref::Util qw/ is_arrayref /;
 
 use Moo::Role;
 use Types::Standard qw(Str CodeRef ArrayRef Map);
-use App::Spec::Types qw(MarkupName PluginType SpecOption SpecParameter SpecSubcommand);
+use App::Spec::Types qw(MarkupName PluginType SpecOption SpecParameter SpecSubcommand CommandOp);
 
 has name => (
     is => 'rw',
@@ -31,7 +31,7 @@ has class => (
 
 has op => (
     is => 'ro',
-    isa => Str|CodeRef,
+    isa => CommandOp,
 );
 
 has plugins => (

--- a/lib/App/Spec/Role/Command.pm
+++ b/lib/App/Spec/Role/Command.pm
@@ -108,7 +108,7 @@ around BUILDARGS => sub {
     $spec->{subcommands} = $commands;
 
     if ( defined (my $op = $spec->{op}) ) {
-        die "Invalid op '$op'" unless $op =~ m/^\w+\z/;
+        die "Invalid op '$op'" unless ref($op) or $op =~ m/^\w+\z/;
     }
     if ( defined (my $class = $spec->{class}) ) {
         die "Invalid class '$class'" unless $class =~ m/^ \w+ (?: ::\w+)* \z/x;

--- a/lib/App/Spec/Run.pm
+++ b/lib/App/Spec/Run.pm
@@ -10,19 +10,63 @@ use App::Spec::Run::Response;
 use Getopt::Long qw/ :config pass_through bundling /;
 use Ref::Util qw/ is_arrayref /;
 use Moo;
+use Types::Standard qw(Map Str ArrayRef Object);
+use App::Spec::Types qw(AppSpec ArgumentValue ValidationErrors CommandOp RunResponse EventSubscriber);
 
-has spec => ( is => 'ro' );
-has options => ( is => 'rw' );
-has parameters => ( is => 'rw', default => sub { +{} } );
-has commands => ( is => 'rw' );
-has argv => ( is => 'rw' );
-has argv_orig => ( is => 'rw' );
+has spec => (
+    is => 'ro',
+    isa => AppSpec,
+    required => 1,
+);
+
+has options => (
+    is => 'rw',
+    isa => Map[Str,ArgumentValue],
+);
+
+has parameters => (
+    is => 'rw',
+    default => sub { +{} },
+    isa => Map[Str,ArgumentValue],
+);
+
+has commands => (
+    is => 'rw',
+    isa => ArrayRef[Str],
+);
+
+has [qw(argv argv_orig)] => (
+    is => 'rw',
+    isa => ArrayRef[Str],
+);
+
 #has runmode => ( is => 'rw', default => 'normal' );
-has validation_errors => ( is => 'rw' );
-has op => ( is => 'rw' );
-has cmd => ( is => 'rw' );
-has response => ( is => 'rw', default => sub { App::Spec::Run::Response->new } );
-has subscribers => ( is => 'rw', default => sub { +{} } );
+has validation_errors => (
+    is => 'rw',
+    isa => ValidationErrors,
+);
+
+has op => (
+    is => 'rw',
+    isa => CommandOp,
+);
+has cmd => (
+    is => 'rw',
+    isa => Object,
+    required => 1,
+);
+
+has response => (
+    is => 'rw',
+    isa => RunResponse,
+    default => sub { App::Spec::Run::Response->new },
+);
+
+has subscribers => (
+    is => 'rw',
+    isa => Map[Str,EventSubscriber],
+    default => sub { +{} },
+);
 
 my %EVENTS = (
     print_output => 1,

--- a/lib/App/Spec/Run/Output.pm
+++ b/lib/App/Spec/Run/Output.pm
@@ -6,10 +6,23 @@ package App::Spec::Run::Output;
 our $VERSION = '0.000'; # VERSION
 
 use Moo;
+use App::Spec::Types qw(RunOutputType);
+use Types::Standard qw(Str Bool);
 
-has type => ( is => 'rw', default => 'plain' );
-has error => ( is => 'rw' );
-has content => ( is => 'rw' );
+has type => (
+    is => 'rw',
+    isa => RunOutputType,
+    default => 'plain',
+);
+has error => (
+    is => 'rw',
+    isa => Bool,
+    default => 0,
+);
+has content => (
+    is => 'rw',
+    isa => Str,
+);
 
 1;
 

--- a/lib/App/Spec/Run/Output.pm
+++ b/lib/App/Spec/Run/Output.pm
@@ -21,7 +21,6 @@ has error => (
 );
 has content => (
     is => 'rw',
-    isa => Str,
 );
 
 1;

--- a/lib/App/Spec/Run/Response.pm
+++ b/lib/App/Spec/Run/Response.pm
@@ -9,13 +9,32 @@ use App::Spec::Run::Output;
 use Scalar::Util qw/ blessed /;
 
 use Moo;
+use App::Spec::Types qw(RunOutput ResponseCallbacks);
+use Types::Standard qw(Int Bool ArrayRef);
 
-has exit => ( is => 'rw', default => 0 );
-has outputs => ( is => 'rw', default => sub { [] } );
-has finished => ( is => 'rw' );
-has halted => ( is => 'rw' );
-has buffered => ( is => 'rw', default => 0 );
-has callbacks => ( is => 'rw', default => sub { +{} } );
+has exit => (
+    is => 'rw',
+    isa => Int,
+    default => 0,
+);
+
+has outputs => (
+    is => 'rw',
+    isa => ArrayRef[RunOutput],
+    default => sub { [] },
+);
+
+has [qw(finished halted buffered)] => (
+    is => 'rw',
+    isa => Bool,
+    default => 0,
+);
+
+has callbacks => (
+    is => 'rw',
+    isa => ResponseCallbacks,
+    default => sub { +{} },
+);
 
 sub add_output {
     my ($self, @out) = @_;

--- a/lib/App/Spec/Run/Response.pm
+++ b/lib/App/Spec/Run/Response.pm
@@ -83,7 +83,7 @@ sub print_output {
     my $outputs = $self->outputs;
     push @$outputs, @out;
 
-    my $callbacks = $self->callbacks->{print_output} || {};
+    my $callbacks = $self->callbacks->{print_output} || [];
     for my $cb (@$callbacks) {
         $cb->();
     }

--- a/lib/App/Spec/Run/Validator.pm
+++ b/lib/App/Spec/Run/Validator.pm
@@ -9,11 +9,30 @@ use List::Util qw/ any /;
 use List::MoreUtils qw/ uniq /;
 use Ref::Util qw/ is_arrayref is_hashref /;
 use Moo;
+use Types::Standard qw(Map Str);
+use App::Spec::Types qw(SpecOption SpecParameter ArgumentValue);
 
-has options => ( is => 'ro' );
-has option_specs => ( is => 'ro' );
-has parameters => ( is => 'ro' );
-has param_specs => ( is => 'ro' );
+has options => (
+    is => 'ro',
+    isa => Map[Str,ArgumentValue],
+);
+
+has option_specs => (
+    is => 'ro',
+    isa => Map[Str,SpecOption],
+    required => 1,
+);
+
+has parameters => (
+    is => 'ro',
+    isa => Map[Str,ArgumentValue],
+);
+
+has param_specs => (
+    is => 'ro',
+    isa => Map[Str,SpecParameter],
+    required => 1,
+);
 
 my %validate = (
     string => sub { length($_[0]) > 0 },

--- a/lib/App/Spec/Types.pm
+++ b/lib/App/Spec/Types.pm
@@ -3,7 +3,12 @@ use strict;
 use warnings;
 package App::Spec::Types;
 use Type::Library -base,
-    -declare => qw( AppSpec RunOutputType ArgumentCompletion CompletionItem ArgumentValues);
+    -declare => qw(
+                      AppSpec
+                      RunOutputType
+                      ArgumentCompletion CompletionItem ArgumentValues
+                      RunOutput ResponseCallbacks
+              );
 use Type::Utils -all;
 use Types::Standard -types;
 use namespace::clean;
@@ -28,5 +33,9 @@ union ArgumentValues, [
     Dict[op => Str|CodeRef],
     Dict[mapping => HashRef[ArrayRef[Str]|Str|Undef]],
 ];
+
+declare ResponseCallbacks, as Map[Str,CodeRef];
+
+class_type RunOutput, { class => 'App::Spec::Run::Output' };
 
 1;

--- a/lib/App/Spec/Types.pm
+++ b/lib/App/Spec/Types.pm
@@ -8,7 +8,7 @@ use Type::Library -base,
                       SpecOption SpecParameter SpecSubcommand
                       RunOutputType
                       SpecArgumentCompletion CompletionItem SpecArgumentValues
-                      ArgumentValue
+                      ArgumentValue ArgumentType
                       RunOutput RunResponse ResponseCallbacks
                       MarkupName
                       PluginType
@@ -56,6 +56,8 @@ class_type RunResponse, { class => 'App::Spec::Run::Response' };
 enum MarkupName, [qw(pod swim)];
 
 enum PluginType, [qw(Subcommands GlobalOptions)];
+
+enum ArgumentType, [qw(string file dir integer flag enum)];
 
 union ArgumentValue, [
     Undef,

--- a/lib/App/Spec/Types.pm
+++ b/lib/App/Spec/Types.pm
@@ -8,6 +8,7 @@ use Type::Library -base,
                       SpecOption SpecParameter SpecSubcommand
                       RunOutputType
                       SpecArgumentCompletion CompletionItem SpecArgumentValues
+                      ArgumentValue
                       RunOutput ResponseCallbacks
                       MarkupName
                       PluginType
@@ -49,5 +50,13 @@ class_type RunOutput, { class => 'App::Spec::Run::Output' };
 enum MarkupName, [qw(pod swim)];
 
 enum PluginType, [qw(Subcommands GlobalOptions)];
+
+union ArgumentValue, [
+    Undef,
+    Str,
+    ArrayRef[Str],
+    HashRef[Str],
+    HashRef[ArrayRef[Str]],
+];
 
 1;

--- a/lib/App/Spec/Types.pm
+++ b/lib/App/Spec/Types.pm
@@ -1,0 +1,26 @@
+# ABSTRACT: type constraints and coercions
+use strict;
+use warnings;
+package App::Spec::Types;
+use Type::Library -base,
+    -declare => qw( AppSpec RunOutputType ArgumentCompletion ArgumentValues);
+use Type::Utils -all;
+use Types::Standard -types;
+use namespace::clean;
+
+class_type AppSpec, { class => 'App::Spec' };
+enum RunOutputType, [qw( plain data )];
+
+union ArgumentCompletion, [
+    Bool,
+    Dict[op => Str|Code],
+    Dict[command => ArrayRef[Str]],
+    Dict[command_string => Str],
+];
+
+union ArgumentValues, [
+    Dict[op => Str|Code],
+    Dict[mapping => HashRef[Str]],
+];
+
+1;

--- a/lib/App/Spec/Types.pm
+++ b/lib/App/Spec/Types.pm
@@ -5,15 +5,23 @@ package App::Spec::Types;
 use Type::Library -base,
     -declare => qw(
                       AppSpec
+                      SpecOption SpecParameter SpecSubcommand
                       RunOutputType
                       ArgumentCompletion CompletionItem ArgumentValues
                       RunOutput ResponseCallbacks
+                      MarkupName
+                      PluginType
               );
 use Type::Utils -all;
 use Types::Standard -types;
 use namespace::clean;
 
 class_type AppSpec, { class => 'App::Spec' };
+
+class_type SpecOption, { class => 'App::Spec::Option' };
+class_type SpecParameter, { class => 'App::Spec::Parameter' };
+class_type SpecSubcommand, { class => 'App::Spec::Subcommand' };
+
 enum RunOutputType, [qw( plain data )];
 
 # Str | { replace => 'SELF' } | { replace => [ SHELL_WORDS => Int ] }
@@ -37,5 +45,9 @@ union ArgumentValues, [
 declare ResponseCallbacks, as Map[Str,CodeRef];
 
 class_type RunOutput, { class => 'App::Spec::Run::Output' };
+
+enum MarkupName, [qw(pod swim)];
+
+enum PluginType, [qw(Subcommands GlobalOptions)];
 
 1;

--- a/lib/App/Spec/Types.pm
+++ b/lib/App/Spec/Types.pm
@@ -11,7 +11,7 @@ use Type::Library -base,
                       ArgumentValue ArgumentType
                       RunOutput RunResponse ResponseCallbacks
                       MarkupName
-                      PluginType
+                      PluginName PluginType
                       ValidationErrors
                       CommandOp
                       EventSubscriber
@@ -54,6 +54,9 @@ class_type RunOutput, { class => 'App::Spec::Run::Output' };
 class_type RunResponse, { class => 'App::Spec::Run::Response' };
 
 enum MarkupName, [qw(pod swim)];
+
+declare PluginName, as Str,
+    where { /[A-Z_a-z][0-9A-Z_a-z]*(?:::[0-9A-Z_a-z]+)/ };
 
 enum PluginType, [qw(Subcommands GlobalOptions)];
 

--- a/lib/App/Spec/Types.pm
+++ b/lib/App/Spec/Types.pm
@@ -9,10 +9,12 @@ use Type::Library -base,
                       RunOutputType
                       SpecArgumentCompletion CompletionItem SpecArgumentValues
                       ArgumentValue
-                      RunOutput ResponseCallbacks
+                      RunOutput RunResponse ResponseCallbacks
                       MarkupName
                       PluginType
+                      ValidationErrors
                       CommandOp
+                      EventSubscriber
               );
 use Type::Utils -all;
 use Types::Standard -types;
@@ -49,6 +51,7 @@ union SpecArgumentValues, [
 declare ResponseCallbacks, as Map[Str,CodeRef];
 
 class_type RunOutput, { class => 'App::Spec::Run::Output' };
+class_type RunResponse, { class => 'App::Spec::Run::Response' };
 
 enum MarkupName, [qw(pod swim)];
 
@@ -60,6 +63,16 @@ union ArgumentValue, [
     ArrayRef[Str],
     HashRef[Str],
     HashRef[ArrayRef[Str]],
+];
+
+declare ValidationErrors, as Dict[
+    parameters => Optional[Map[Str,Str]],
+    options => Optional[Map[Str,Str]],
+];
+
+declare EventSubscriber, as Dict[
+    plugin => ClassName|Object,
+    method => CommandOp,
 ];
 
 1;

--- a/lib/App/Spec/Types.pm
+++ b/lib/App/Spec/Types.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 package App::Spec::Types;
 use Type::Library -base,
-    -declare => qw( AppSpec RunOutputType ArgumentCompletion ArgumentValues);
+    -declare => qw( AppSpec RunOutputType ArgumentCompletion CompletionItem ArgumentValues);
 use Type::Utils -all;
 use Types::Standard -types;
 use namespace::clean;
@@ -11,16 +11,22 @@ use namespace::clean;
 class_type AppSpec, { class => 'App::Spec' };
 enum RunOutputType, [qw( plain data )];
 
+# Str | { replace => 'SELF' } | { replace => [ SHELL_WORDS => Int ] }
+union CompletionItem, [
+    Str,
+    Dict[replace => ( Enum['SELF'] | Tuple[Enum['SHELL_WORDS'],Int] )],
+];
+
 union ArgumentCompletion, [
     Bool,
-    Dict[op => Str|Code],
-    Dict[command => ArrayRef[Str]],
+    Dict[op => Str|CodeRef],
+    Dict[command => ArrayRef[CompletionItem]],
     Dict[command_string => Str],
 ];
 
 union ArgumentValues, [
-    Dict[op => Str|Code],
-    Dict[mapping => HashRef[Str]],
+    Dict[op => Str|CodeRef],
+    Dict[mapping => HashRef[ArrayRef[Str]|Str|Undef]],
 ];
 
 1;

--- a/lib/App/Spec/Types.pm
+++ b/lib/App/Spec/Types.pm
@@ -7,7 +7,7 @@ use Type::Library -base,
                       AppSpec
                       SpecOption SpecParameter SpecSubcommand
                       RunOutputType
-                      ArgumentCompletion CompletionItem ArgumentValues
+                      SpecArgumentCompletion CompletionItem SpecArgumentValues
                       RunOutput ResponseCallbacks
                       MarkupName
                       PluginType
@@ -30,14 +30,14 @@ union CompletionItem, [
     Dict[replace => ( Enum['SELF'] | Tuple[Enum['SHELL_WORDS'],Int] )],
 ];
 
-union ArgumentCompletion, [
+union SpecArgumentCompletion, [
     Bool,
     Dict[op => Str|CodeRef],
     Dict[command => ArrayRef[CompletionItem]],
     Dict[command_string => Str],
 ];
 
-union ArgumentValues, [
+union SpecArgumentValues, [
     Dict[op => Str|CodeRef],
     Dict[mapping => HashRef[ArrayRef[Str]|Str|Undef]],
 ];

--- a/lib/App/Spec/Types.pm
+++ b/lib/App/Spec/Types.pm
@@ -12,6 +12,7 @@ use Type::Library -base,
                       RunOutput ResponseCallbacks
                       MarkupName
                       PluginType
+                      CommandOp
               );
 use Type::Utils -all;
 use Types::Standard -types;
@@ -31,15 +32,17 @@ union CompletionItem, [
     Dict[replace => ( Enum['SELF'] | Tuple[Enum['SHELL_WORDS'],Int] )],
 ];
 
+union CommandOp, [Str,CodeRef];
+
 union SpecArgumentCompletion, [
     Bool,
-    Dict[op => Str|CodeRef],
+    Dict[op => CommandOp],
     Dict[command => ArrayRef[CompletionItem]],
     Dict[command_string => Str],
 ];
 
 union SpecArgumentValues, [
-    Dict[op => Str|CodeRef],
+    Dict[op => CommandOp],
     Dict[mapping => HashRef[ArrayRef[Str]|Str|Undef]],
 ];
 

--- a/t/13.argv.t
+++ b/t/13.argv.t
@@ -27,7 +27,7 @@ $ENV{PERL5_APPSPECRUN_TEST} = 1;
     my $res1 = $runner1->response;
     my $res2 = $runner2->response;
     # we don't care about the callbacks here
-    $_->callbacks([]) for ($res1, $res2);
+    $_->callbacks({}) for ($res1, $res2);
     cmp_deeply(
         $res1,
         $res2,


### PR DESCRIPTION
In reference to #14, here's a few changes:
* type constraints everywhere: among other things, this makes clearer what each attribute can accept
* defaults for all attributes where it makes sense
* `BUILDARGS`/`new` instead of `common`/`build`, this makes classes easier to use and extend
* `op` now canonically accepts a coderef (previously it did, but probably by mistake: it's a useful feature, let's support it properly)

Needed before merging:
* documentation for all the type constraints
* better names for them

Possible future work:
* review the various enums
* review the various union types, and check if they really make sense 
* reduce the number of `rw` attributes