### PR TITLE
proposed changes to use more of Moo, second attempt

### DIFF
--- a/lib/App/Spec.pm
+++ b/lib/App/Spec.pm
@@ -15,8 +15,8 @@ use Moo;
 
 with('App::Spec::Role::Command');
 
-has title => ( is => 'rw' );
-has abstract => ( is => 'rw' );
+has title => ( is => 'rw', required => 1 );
+has abstract => ( is => 'rw', default => '' );
 
 
 

--- a/lib/App/Spec.pm
+++ b/lib/App/Spec.pm
@@ -362,11 +362,11 @@ Takes a file, hashref or glob and returns generated appspec hashref
 
     my $hash = $class->load_data($file);
 
-=item build
+=item new
 
-Builds objects out of the hashref
+Constructor.
 
-    my $appspec = App::Spec->build(%hash);
+    my $appspec = App::Spec->new(%hash);
 
 =item runner
 

--- a/lib/App/Spec.pm
+++ b/lib/App/Spec.pm
@@ -10,13 +10,14 @@ use App::Spec::Subcommand;
 use App::Spec::Option;
 use App::Spec::Parameter;
 use YAML::XS ();
+use Types::Standard qw/Str/;
 
 use Moo;
 
 with('App::Spec::Role::Command');
 
-has title => ( is => 'rw', required => 1 );
-has abstract => ( is => 'rw', default => '' );
+has title => ( is => 'rw', isa => Str, required => 1 );
+has abstract => ( is => 'rw', isa => Str, default => '' );
 
 
 

--- a/lib/App/Spec/Argument.pm
+++ b/lib/App/Spec/Argument.pm
@@ -8,13 +8,13 @@ our $VERSION = '0.000'; # VERSION
 use Moo;
 
 has name => ( is => 'ro' );
-has type => ( is => 'ro' );
-has multiple => ( is => 'ro' );
-has mapping => ( is => 'ro' );
-has required => ( is => 'ro' );
-has unique => ( is => 'ro' );
-has summary => ( is => 'ro' );
-has description => ( is => 'ro' );
+has type => ( is => 'ro', default => 'string' );
+has multiple => ( is => 'ro', default => 0 );
+has mapping => ( is => 'ro', default => 0 );
+has required => ( is => 'ro', default => 0 );
+has unique => ( is => 'ro', default => 0 );
+has summary => ( is => 'ro', default => '' );
+has description => ( is => 'ro', default => '' );
 has default => ( is => 'ro' );
 has completion => ( is => 'ro' );
 has enum => ( is => 'ro' );
@@ -27,25 +27,12 @@ around BUILDARGS => sub {
     if (defined $args->{spec}) {
         %dsl = $class->from_dsl(delete $args->{spec});
     }
-    my $description = $args->{description};
-    my $summary = $args->{summary};
-    $summary //= '';
-    $description //= '';
-    my $type = $args->{type} // 'string';
     my %hash = (
         %{$args},
-        name => $args->{name},
-        summary => $summary,
-        description => $description,
-        type => $type,
         multiple => $args->{multiple} ? 1 : 0,
         mapping => $args->{mapping} ? 1 : 0,
         required => $args->{required} ? 1 : 0,
         unique => $args->{unique} ? 1 : 0,
-        default => $args->{default},
-        completion => $args->{completion},
-        enum => $args->{enum},
-        values => $args->{values},
         %dsl,
     );
     not defined $hash{ $_ } and delete $hash{ $_ } for keys %hash;

--- a/lib/App/Spec/Argument.pm
+++ b/lib/App/Spec/Argument.pm
@@ -5,11 +5,12 @@ package App::Spec::Argument;
 
 our $VERSION = '0.000'; # VERSION
 use Types::Standard qw/Str Bool ArrayRef/;
+use App::Spec::Types qw/ ArgumentType /;
 
 use Moo;
 
 has name => ( is => 'ro', isa => Str, required => 1 );
-has type => ( is => 'ro', default => 'string' );
+has type => ( is => 'ro', isa => ArgumentType, default => 'string' );
 has multiple => ( is => 'ro', isa => Bool, default => 0 );
 has mapping => ( is => 'ro', isa => Bool, default => 0 );
 has required => ( is => 'ro', isa => Bool, default => 0 );

--- a/lib/App/Spec/Argument.pm
+++ b/lib/App/Spec/Argument.pm
@@ -4,20 +4,21 @@ use warnings;
 package App::Spec::Argument;
 
 our $VERSION = '0.000'; # VERSION
+use Types::Standard qw/Str Bool ArrayRef/;
 
 use Moo;
 
-has name => ( is => 'ro' );
+has name => ( is => 'ro', isa => Str, required => 1 );
 has type => ( is => 'ro', default => 'string' );
-has multiple => ( is => 'ro', default => 0 );
-has mapping => ( is => 'ro', default => 0 );
-has required => ( is => 'ro', default => 0 );
-has unique => ( is => 'ro', default => 0 );
-has summary => ( is => 'ro', default => '' );
-has description => ( is => 'ro', default => '' );
-has default => ( is => 'ro' );
+has multiple => ( is => 'ro', isa => Bool, default => 0 );
+has mapping => ( is => 'ro', isa => Bool, default => 0 );
+has required => ( is => 'ro', isa => Bool, default => 0 );
+has unique => ( is => 'ro', isa => Bool, default => 0 );
+has summary => ( is => 'ro', isa => Str, default => '' );
+has description => ( is => 'ro', isa => Str, default => '' );
+has default => ( is => 'ro', isa => Str );
 has completion => ( is => 'ro' );
-has enum => ( is => 'ro' );
+has enum => ( is => 'ro', isa => ArrayRef[Str] );
 has values => ( is => 'ro' );
 
 around BUILDARGS => sub {

--- a/lib/App/Spec/Argument.pm
+++ b/lib/App/Spec/Argument.pm
@@ -31,10 +31,6 @@ around BUILDARGS => sub {
     }
     my %hash = (
         %{$args},
-        multiple => $args->{multiple} ? 1 : 0,
-        mapping => $args->{mapping} ? 1 : 0,
-        required => $args->{required} ? 1 : 0,
-        unique => $args->{unique} ? 1 : 0,
         %dsl,
     );
     not defined $hash{ $_ } and delete $hash{ $_ } for keys %hash;

--- a/lib/App/Spec/Argument.pm
+++ b/lib/App/Spec/Argument.pm
@@ -5,7 +5,7 @@ package App::Spec::Argument;
 
 our $VERSION = '0.000'; # VERSION
 use Types::Standard qw/Str Bool ArrayRef/;
-use App::Spec::Types qw/ ArgumentType /;
+use App::Spec::Types qw/ SpecArgumentCompletion SpecArgumentValues ArgumentType /;
 
 use Moo;
 
@@ -18,9 +18,9 @@ has unique => ( is => 'ro', isa => Bool, default => 0 );
 has summary => ( is => 'ro', isa => Str, default => '' );
 has description => ( is => 'ro', isa => Str, default => '' );
 has default => ( is => 'ro', isa => Str );
-has completion => ( is => 'ro' );
+has completion => ( is => 'ro', isa => SpecArgumentCompletion, default => 0 );
 has enum => ( is => 'ro', isa => ArrayRef[Str] );
-has values => ( is => 'ro' );
+has values => ( is => 'ro', isa => SpecArgumentValues );
 
 around BUILDARGS => sub {
     my ($orig, $class, @etc) = @_;

--- a/lib/App/Spec/Argument.pm
+++ b/lib/App/Spec/Argument.pm
@@ -20,35 +20,37 @@ has completion => ( is => 'ro' );
 has enum => ( is => 'ro' );
 has values => ( is => 'ro' );
 
-sub common {
-    my ($class, %args) = @_;
+around BUILDARGS => sub {
+    my ($orig, $class, @etc) = @_;
+    my $args = $class->$orig(@etc);
     my %dsl;
-    if (defined $args{spec}) {
-        %dsl = $class->from_dsl(delete $args{spec});
+    if (defined $args->{spec}) {
+        %dsl = $class->from_dsl(delete $args->{spec});
     }
-    my $description = $args{description};
-    my $summary = $args{summary};
+    my $description = $args->{description};
+    my $summary = $args->{summary};
     $summary //= '';
     $description //= '';
-    my $type = $args{type} // 'string';
+    my $type = $args->{type} // 'string';
     my %hash = (
-        name => $args{name},
+        %{$args},
+        name => $args->{name},
         summary => $summary,
         description => $description,
         type => $type,
-        multiple => $args{multiple} ? 1 : 0,
-        mapping => $args{mapping} ? 1 : 0,
-        required => $args{required} ? 1 : 0,
-        unique => $args{unique} ? 1 : 0,
-        default => $args{default},
-        completion => $args{completion},
-        enum => $args{enum},
-        values => $args{values},
+        multiple => $args->{multiple} ? 1 : 0,
+        mapping => $args->{mapping} ? 1 : 0,
+        required => $args->{required} ? 1 : 0,
+        unique => $args->{unique} ? 1 : 0,
+        default => $args->{default},
+        completion => $args->{completion},
+        enum => $args->{enum},
+        values => $args->{values},
         %dsl,
     );
     not defined $hash{ $_ } and delete $hash{ $_ } for keys %hash;
-    return %hash;
-}
+    return \%hash;
+};
 
 my $name_re = qr{[\w-]+};
 
@@ -235,11 +237,12 @@ STOP INLINE
 
 =over 4
 
-=item common
+=item BUILDARGS
 
-Builds a hash with the given hashref and fills in some defaults.
+Builds a hash with the given hashref and fills in some
+defaults. Invoked as part of the normal constructor.
 
-    my %hash = $class->common($args);
+    my $object = $class->new(\%args);
 
 =item from_dsl
 

--- a/lib/App/Spec/Completion.pm
+++ b/lib/App/Spec/Completion.pm
@@ -6,8 +6,9 @@ package App::Spec::Completion;
 our $VERSION = '0.000'; # VERSION
 
 use Moo;
+use App::Spec::Types qw/AppSpec/;
 
-has spec => ( is => 'ro' );
+has spec => ( is => 'ro', required => 1, isa => AppSpec );
 
 1;
 

--- a/lib/App/Spec/Option.pm
+++ b/lib/App/Spec/Option.pm
@@ -5,19 +5,14 @@ package App::Spec::Option;
 
 our $VERSION = '0.000'; # VERSION
 
-use base 'App::Spec::Argument';
 use Moo;
+extends 'App::Spec::Argument';
 
-has aliases => ( is => 'ro' );
+has aliases => ( is => 'ro', default => sub { [] } );
 
 sub build {
-    my ($class, %args) = @_;
-    my %hash = $class->common(%args);
-    my $self = $class->new({
-        aliases => $args{aliases} || [],
-        %hash,
-    });
-    return $self;
+    my ($class, @args) = @_;
+    return $class->new(@args);
 }
 
 1;

--- a/lib/App/Spec/Option.pm
+++ b/lib/App/Spec/Option.pm
@@ -10,6 +10,7 @@ extends 'App::Spec::Argument';
 
 has aliases => ( is => 'ro', default => sub { [] } );
 
+# back-compat for old versions
 sub build {
     my ($class, @args) = @_;
     return $class->new(@args);
@@ -31,9 +32,9 @@ This class inherits from L<App::Spec::Argument>
 
 =over 4
 
-=item build
+=item new
 
-    my $option = App::Spec::Option->build(
+    my $option = App::Spec::Option->new(
         name => 'verbose',
         summary => 'lala',
         aliases => ['v'],

--- a/lib/App/Spec/Option.pm
+++ b/lib/App/Spec/Option.pm
@@ -4,11 +4,12 @@ use warnings;
 package App::Spec::Option;
 
 our $VERSION = '0.000'; # VERSION
+use Types::Standard qw/Str ArrayRef/;
 
 use Moo;
 extends 'App::Spec::Argument';
 
-has aliases => ( is => 'ro', default => sub { [] } );
+has aliases => ( is => 'ro', isa => ArrayRef[Str], default => sub { [] } );
 
 # back-compat for old versions
 sub build {

--- a/lib/App/Spec/Parameter.pm
+++ b/lib/App/Spec/Parameter.pm
@@ -8,6 +8,7 @@ our $VERSION = '0.000'; # VERSION
 use Moo;
 extends 'App::Spec::Argument';
 
+# back-compat for old versions
 sub build {
     my ($class, @args) = @_;
     return $class->new(@args);
@@ -47,9 +48,9 @@ This class inherits from L<App::Spec::Argument>
 
 =over 4
 
-=item build
+=item new
 
-    my $param = App::Spec::Parameter->build(
+    my $param = App::Spec::Parameter->new(
         name => 'verbose',
         summary => 'lala',
     );

--- a/lib/App/Spec/Parameter.pm
+++ b/lib/App/Spec/Parameter.pm
@@ -5,16 +5,12 @@ package App::Spec::Parameter;
 
 our $VERSION = '0.000'; # VERSION
 
-use base 'App::Spec::Argument';
 use Moo;
+extends 'App::Spec::Argument';
 
 sub build {
-    my ($class, %args) = @_;
-    my %hash = $class->common(%args);
-    my $self = $class->new({
-        %hash,
-    });
-    return $self;
+    my ($class, @args) = @_;
+    return $class->new(@args);
 }
 
 sub to_usage_header {

--- a/lib/App/Spec/Pod.pm
+++ b/lib/App/Spec/Pod.pm
@@ -8,8 +8,9 @@ our $VERSION = '0.000'; # VERSION
 use Text::Table;
 
 use Moo;
+use App::Spec::Types qw/AppSpec/;
 
-has spec => ( is => 'ro' );
+has spec => ( is => 'ro', required => 1, isa => AppSpec );
 
 sub generate {
     my ($self) = @_;

--- a/lib/App/Spec/Role/Command.pm
+++ b/lib/App/Spec/Role/Command.pm
@@ -62,6 +62,15 @@ around BUILDARGS => sub {
         die "Invalid class '$class'" unless $class =~ m/^ \w+ (?: ::\w+)* \z/x;
     }
 
+    my @plugins = $class->default_plugins;
+    push @plugins, @{ $spec->{plugins} || [] };
+    for my $plugin (@plugins) {
+        unless ($plugin =~ s/^=//) {
+            $plugin = "App::Spec::Plugin::$plugin";
+        }
+    }
+    $spec->{plugins} = \@plugins;
+
     return $spec;
 };
 
@@ -78,15 +87,6 @@ sub read {
     }
 
     my $spec = $class->load_data($file);
-
-    my @plugins = $class->default_plugins;
-    push @plugins, @{ $spec->{plugins} || [] };
-    for my $plugin (@plugins) {
-        unless ($plugin =~ s/^=//) {
-            $plugin = "App::Spec::Plugin::$plugin";
-        }
-    }
-    $spec->{plugins} = \@plugins;
 
     my $self = $class->new($spec);
 

--- a/lib/App/Spec/Role/Command.pm
+++ b/lib/App/Spec/Role/Command.pm
@@ -7,19 +7,20 @@ our $VERSION = '0.000'; # VERSION
 use List::Util qw/ any /;
 use App::Spec::Option;
 use Ref::Util qw/ is_arrayref is_blessed_ref /;
+use Types::Standard qw/ Str /;
 
 use Moo::Role;
 
-has name => ( is => 'rw' );
+has name => ( is => 'rw', required => 1, isa => Str );
 has markup => ( is => 'rw', default => 'pod' );
-has class => ( is => 'rw' );
+has class => ( is => 'rw', isa => Str );
 has op => ( is => 'ro' );
 has plugins => ( is => 'ro', default => sub { +[] } );
 has plugins_by_type => ( is => 'ro', default => sub { +{} } );
 has options => ( is => 'rw', default => sub { +[] } );
 has parameters => ( is => 'rw', default => sub { +[] } );
 has subcommands => ( is => 'rw', default => sub { +{} } );
-has description => ( is => 'rw' );
+has description => ( is => 'rw', isa => Str );
 
 sub default_plugins {
     qw/ Meta Help /

--- a/lib/App/Spec/Role/Command.pm
+++ b/lib/App/Spec/Role/Command.pm
@@ -74,6 +74,16 @@ around BUILDARGS => sub {
     return $spec;
 };
 
+# trick to make sure plugins are inited even when the consuming class
+# defines its own BUILD
+sub BUILD {}
+before BUILD => sub {
+    my ($self) = @_;
+    $self->load_plugins;
+    $self->init_plugins;
+    return;
+};
+
 # back-compat for old versions
 sub build {
     my ($class, @spec) = @_;
@@ -89,9 +99,6 @@ sub read {
     my $spec = $class->load_data($file);
 
     my $self = $class->new($spec);
-
-    $self->load_plugins;
-    $self->init_plugins;
 
     return $self;
 }

--- a/lib/App/Spec/Role/Command.pm
+++ b/lib/App/Spec/Role/Command.pm
@@ -14,7 +14,7 @@ has name => ( is => 'rw' );
 has markup => ( is => 'rw', default => 'pod' );
 has class => ( is => 'rw' );
 has op => ( is => 'ro' );
-has plugins => ( is => 'ro' );
+has plugins => ( is => 'ro', default => sub { +[] } );
 has plugins_by_type => ( is => 'ro', default => sub { +{} } );
 has options => ( is => 'rw', default => sub { +[] } );
 has parameters => ( is => 'rw', default => sub { +[] } );
@@ -34,8 +34,6 @@ around BUILDARGS => sub {
     my ($orig,$class,@etc) = @_;
     my $spec = $class->$orig(@etc);
 
-    $spec->{options} ||= [];
-    $spec->{parameters} ||= [];
     for (@{ $spec->{options} }, @{ $spec->{parameters} }) {
         $_ = { spec => $_ } unless ref $_;
     }

--- a/lib/App/Spec/Role/Command.pm
+++ b/lib/App/Spec/Role/Command.pm
@@ -8,16 +8,16 @@ use List::Util qw/ any /;
 use App::Spec::Option;
 use Ref::Util qw/ is_arrayref is_blessed_ref /;
 use Types::Standard qw/ Map Str ArrayRef /;
-use App::Spec::Types qw/ SpecOption SpecParameter SpecSubcommand /;
+use App::Spec::Types qw/ MarkupName PluginName PluginType SpecOption SpecParameter SpecSubcommand /;
 
 use Moo::Role;
 
 has name => ( is => 'rw', required => 1, isa => Str );
-has markup => ( is => 'rw', default => 'pod' );
+has markup => ( is => 'rw', isa => MarkupName, default => 'pod' );
 has class => ( is => 'rw', isa => Str );
 has op => ( is => 'ro' );
-has plugins => ( is => 'ro', default => sub { +[] } );
-has plugins_by_type => ( is => 'ro', default => sub { +{} } );
+has plugins => ( is => 'ro', isa => ArrayRef[PluginName], default => sub { +[] } );
+has plugins_by_type => ( is => 'ro', isa => Map[PluginType,PluginName], default => sub { +{} } );
 has options => ( is => 'rw', isa => ArrayRef[SpecOption], default => sub { +[] } );
 has parameters => ( is => 'rw', isa => ArrayRef[SpecParameter], default => sub { +[] } );
 has subcommands => ( is => 'rw', isa => Map[Str,SpecSubcommand], default => sub { +{} } );

--- a/lib/App/Spec/Role/Command.pm
+++ b/lib/App/Spec/Role/Command.pm
@@ -8,14 +8,14 @@ use List::Util qw/ any /;
 use App::Spec::Option;
 use Ref::Util qw/ is_arrayref is_blessed_ref /;
 use Types::Standard qw/ Map Str ArrayRef /;
-use App::Spec::Types qw/ MarkupName PluginName PluginType SpecOption SpecParameter SpecSubcommand /;
+use App::Spec::Types qw/ MarkupName PluginName PluginType SpecOption SpecParameter SpecSubcommand CommandOp /;
 
 use Moo::Role;
 
 has name => ( is => 'rw', required => 1, isa => Str );
 has markup => ( is => 'rw', isa => MarkupName, default => 'pod' );
 has class => ( is => 'rw', isa => Str );
-has op => ( is => 'ro' );
+has op => ( is => 'ro', isa => CommandOp );
 has plugins => ( is => 'ro', isa => ArrayRef[PluginName], default => sub { +[] } );
 has plugins_by_type => ( is => 'ro', isa => Map[PluginType,PluginName], default => sub { +{} } );
 has options => ( is => 'rw', isa => ArrayRef[SpecOption], default => sub { +[] } );

--- a/lib/App/Spec/Role/Command.pm
+++ b/lib/App/Spec/Role/Command.pm
@@ -56,7 +56,7 @@ around BUILDARGS => sub {
     $spec->{subcommands} = $commands;
 
     if ( defined (my $op = $spec->{op}) ) {
-        die "Invalid op '$op'" unless $op =~ m/^\w+\z/;
+        die "Invalid op '$op'" unless ref($op) || $op =~ m/^\w+\z/;
     }
     if ( defined (my $class = $spec->{class}) ) {
         die "Invalid class '$class'" unless $class =~ m/^ \w+ (?: ::\w+)* \z/x;

--- a/lib/App/Spec/Run.pm
+++ b/lib/App/Spec/Run.pm
@@ -7,10 +7,10 @@ our $VERSION = '0.000'; # VERSION
 
 use App::Spec::Run::Validator;
 use App::Spec::Run::Response;
-use App::Spec::Types qw/ AppSpec RunResponse /;
+use App::Spec::Types qw/ AppSpec ValidationErrors RunResponse EventSubscriber /;
 use Getopt::Long qw/ :config pass_through bundling /;
 use Ref::Util qw/ is_arrayref /;
-use Types::Standard qw/ Str ArrayRef Object /;
+use Types::Standard qw/ Map Str ArrayRef Object /;
 use Moo;
 
 has spec => ( is => 'ro', required => 1, isa => AppSpec );
@@ -20,11 +20,11 @@ has commands => ( is => 'rw', isa => ArrayRef[Str] );
 has argv => ( is => 'rw', isa => ArrayRef[Str] );
 has argv_orig => ( is => 'rw', isa => ArrayRef[Str] );
 #has runmode => ( is => 'rw', default => 'normal' );
-has validation_errors => ( is => 'rw' );
+has validation_errors => ( is => 'rw', isa => ValidationErrors );
 has op => ( is => 'rw' );
 has cmd => ( is => 'rw', isa => Object );
 has response => ( is => 'rw', isa => RunResponse, default => sub { App::Spec::Run::Response->new } );
-has subscribers => ( is => 'rw', default => sub { +{} } );
+has subscribers => ( is => 'rw', isa => Map[Str,EventSubscriber], default => sub { +{} } );
 
 my %EVENTS = (
     print_output => 1,

--- a/lib/App/Spec/Run.pm
+++ b/lib/App/Spec/Run.pm
@@ -7,11 +7,12 @@ our $VERSION = '0.000'; # VERSION
 
 use App::Spec::Run::Validator;
 use App::Spec::Run::Response;
+use App::Spec::Types qw/AppSpec/;
 use Getopt::Long qw/ :config pass_through bundling /;
 use Ref::Util qw/ is_arrayref /;
 use Moo;
 
-has spec => ( is => 'ro' );
+has spec => ( is => 'ro', required => 1, isa => AppSpec );
 has options => ( is => 'rw' );
 has parameters => ( is => 'rw', default => sub { +{} } );
 has commands => ( is => 'rw' );

--- a/lib/App/Spec/Run.pm
+++ b/lib/App/Spec/Run.pm
@@ -7,21 +7,21 @@ our $VERSION = '0.000'; # VERSION
 
 use App::Spec::Run::Validator;
 use App::Spec::Run::Response;
-use App::Spec::Types qw/ AppSpec ValidationErrors RunResponse EventSubscriber /;
+use App::Spec::Types qw/ AppSpec ArgumentValue ValidationErrors CommandOp RunResponse EventSubscriber /;
 use Getopt::Long qw/ :config pass_through bundling /;
 use Ref::Util qw/ is_arrayref /;
 use Types::Standard qw/ Map Str ArrayRef Object /;
 use Moo;
 
 has spec => ( is => 'ro', required => 1, isa => AppSpec );
-has options => ( is => 'rw' );
-has parameters => ( is => 'rw', default => sub { +{} } );
+has options => ( is => 'rw', isa => Map[Str,ArgumentValue] );
+has parameters => ( is => 'rw', isa => Map[Str,ArgumentValue], default => sub { +{} } );
 has commands => ( is => 'rw', isa => ArrayRef[Str] );
 has argv => ( is => 'rw', isa => ArrayRef[Str] );
 has argv_orig => ( is => 'rw', isa => ArrayRef[Str] );
 #has runmode => ( is => 'rw', default => 'normal' );
 has validation_errors => ( is => 'rw', isa => ValidationErrors );
-has op => ( is => 'rw' );
+has op => ( is => 'rw', isa => CommandOp );
 has cmd => ( is => 'rw', isa => Object );
 has response => ( is => 'rw', isa => RunResponse, default => sub { App::Spec::Run::Response->new } );
 has subscribers => ( is => 'rw', isa => Map[Str,EventSubscriber], default => sub { +{} } );

--- a/lib/App/Spec/Run.pm
+++ b/lib/App/Spec/Run.pm
@@ -10,18 +10,19 @@ use App::Spec::Run::Response;
 use App::Spec::Types qw/AppSpec/;
 use Getopt::Long qw/ :config pass_through bundling /;
 use Ref::Util qw/ is_arrayref /;
+use Types::Standard qw/ Str ArrayRef Object /;
 use Moo;
 
 has spec => ( is => 'ro', required => 1, isa => AppSpec );
 has options => ( is => 'rw' );
 has parameters => ( is => 'rw', default => sub { +{} } );
-has commands => ( is => 'rw' );
-has argv => ( is => 'rw' );
-has argv_orig => ( is => 'rw' );
+has commands => ( is => 'rw', isa => ArrayRef[Str] );
+has argv => ( is => 'rw', isa => ArrayRef[Str] );
+has argv_orig => ( is => 'rw', isa => ArrayRef[Str] );
 #has runmode => ( is => 'rw', default => 'normal' );
 has validation_errors => ( is => 'rw' );
 has op => ( is => 'rw' );
-has cmd => ( is => 'rw' );
+has cmd => ( is => 'rw', isa => Object );
 has response => ( is => 'rw', default => sub { App::Spec::Run::Response->new } );
 has subscribers => ( is => 'rw', default => sub { +{} } );
 

--- a/lib/App/Spec/Run.pm
+++ b/lib/App/Spec/Run.pm
@@ -7,7 +7,7 @@ our $VERSION = '0.000'; # VERSION
 
 use App::Spec::Run::Validator;
 use App::Spec::Run::Response;
-use App::Spec::Types qw/AppSpec/;
+use App::Spec::Types qw/ AppSpec RunResponse /;
 use Getopt::Long qw/ :config pass_through bundling /;
 use Ref::Util qw/ is_arrayref /;
 use Types::Standard qw/ Str ArrayRef Object /;
@@ -23,7 +23,7 @@ has argv_orig => ( is => 'rw', isa => ArrayRef[Str] );
 has validation_errors => ( is => 'rw' );
 has op => ( is => 'rw' );
 has cmd => ( is => 'rw', isa => Object );
-has response => ( is => 'rw', default => sub { App::Spec::Run::Response->new } );
+has response => ( is => 'rw', isa => RunResponse, default => sub { App::Spec::Run::Response->new } );
 has subscribers => ( is => 'rw', default => sub { +{} } );
 
 my %EVENTS = (

--- a/lib/App/Spec/Run/Output.pm
+++ b/lib/App/Spec/Run/Output.pm
@@ -5,10 +5,11 @@ package App::Spec::Run::Output;
 
 our $VERSION = '0.000'; # VERSION
 use Types::Standard qw/Bool/;
+use App::Spec::Types qw/RunOutputType/;
 
 use Moo;
 
-has type => ( is => 'rw', default => 'plain' );
+has type => ( is => 'rw', isa => RunOutputType, default => 'plain' );
 has error => ( is => 'rw', isa => Bool, default => 0 );
 has content => ( is => 'rw' );
 

--- a/lib/App/Spec/Run/Output.pm
+++ b/lib/App/Spec/Run/Output.pm
@@ -4,11 +4,12 @@ use warnings;
 package App::Spec::Run::Output;
 
 our $VERSION = '0.000'; # VERSION
+use Types::Standard qw/Bool/;
 
 use Moo;
 
 has type => ( is => 'rw', default => 'plain' );
-has error => ( is => 'rw' );
+has error => ( is => 'rw', isa => Bool, default => 0 );
 has content => ( is => 'rw' );
 
 1;

--- a/lib/App/Spec/Run/Response.pm
+++ b/lib/App/Spec/Run/Response.pm
@@ -8,11 +8,12 @@ our $VERSION = '0.000'; # VERSION
 use App::Spec::Run::Output;
 use Scalar::Util qw/ blessed /;
 use Types::Standard qw/ Int Bool ArrayRef /;
+use App::Spec::Types qw/ RunOutput /;
 
 use Moo;
 
 has exit => ( is => 'rw', isa => Int, default => 0 );
-has outputs => ( is => 'rw', default => sub { [] } );
+has outputs => ( is => 'rw', isa => ArrayRef[RunOutput], default => sub { [] } );
 has finished => ( is => 'rw', isa => Bool, default => 0 );
 has halted => ( is => 'rw', isa => Bool, default => 0 );
 has buffered => ( is => 'rw', isa => Bool, default => 0 );

--- a/lib/App/Spec/Run/Response.pm
+++ b/lib/App/Spec/Run/Response.pm
@@ -65,7 +65,7 @@ sub print_output {
     my $outputs = $self->outputs;
     push @$outputs, @out;
 
-    my $callbacks = $self->callbacks->{print_output} || {};
+    my $callbacks = $self->callbacks->{print_output} || [];
     for my $cb (@$callbacks) {
         $cb->();
     }

--- a/lib/App/Spec/Run/Response.pm
+++ b/lib/App/Spec/Run/Response.pm
@@ -8,7 +8,7 @@ our $VERSION = '0.000'; # VERSION
 use App::Spec::Run::Output;
 use Scalar::Util qw/ blessed /;
 use Types::Standard qw/ Int Bool ArrayRef /;
-use App::Spec::Types qw/ RunOutput /;
+use App::Spec::Types qw/ RunOutput ResponseCallbacks /;
 
 use Moo;
 
@@ -17,7 +17,7 @@ has outputs => ( is => 'rw', isa => ArrayRef[RunOutput], default => sub { [] } )
 has finished => ( is => 'rw', isa => Bool, default => 0 );
 has halted => ( is => 'rw', isa => Bool, default => 0 );
 has buffered => ( is => 'rw', isa => Bool, default => 0 );
-has callbacks => ( is => 'rw', default => sub { +{} } );
+has callbacks => ( is => 'rw', isa => ResponseCallbacks, default => sub { +{} } );
 
 sub add_output {
     my ($self, @out) = @_;

--- a/lib/App/Spec/Run/Response.pm
+++ b/lib/App/Spec/Run/Response.pm
@@ -7,14 +7,15 @@ our $VERSION = '0.000'; # VERSION
 
 use App::Spec::Run::Output;
 use Scalar::Util qw/ blessed /;
+use Types::Standard qw/ Int Bool ArrayRef /;
 
 use Moo;
 
-has exit => ( is => 'rw', default => 0 );
+has exit => ( is => 'rw', isa => Int, default => 0 );
 has outputs => ( is => 'rw', default => sub { [] } );
-has finished => ( is => 'rw' );
-has halted => ( is => 'rw' );
-has buffered => ( is => 'rw', default => 0 );
+has finished => ( is => 'rw', isa => Bool, default => 0 );
+has halted => ( is => 'rw', isa => Bool, default => 0 );
+has buffered => ( is => 'rw', isa => Bool, default => 0 );
 has callbacks => ( is => 'rw', default => sub { +{} } );
 
 sub add_output {

--- a/lib/App/Spec/Run/Validator.pm
+++ b/lib/App/Spec/Run/Validator.pm
@@ -8,12 +8,14 @@ our $VERSION = '0.000'; # VERSION;
 use List::Util qw/ any /;
 use List::MoreUtils qw/ uniq /;
 use Ref::Util qw/ is_arrayref is_hashref /;
+use Types::Standard qw/ Map Str /;
+use App::Spec::Types qw/ SpecOption SpecParameter /;
 use Moo;
 
 has options => ( is => 'ro' );
-has option_specs => ( is => 'ro' );
+has option_specs => ( is => 'ro', isa => Map[Str,SpecOption] );
 has parameters => ( is => 'ro' );
-has param_specs => ( is => 'ro' );
+has param_specs => ( is => 'ro', isa => Map[Str,SpecParameter], required => 1 );
 
 my %validate = (
     string => sub { length($_[0]) > 0 },

--- a/lib/App/Spec/Run/Validator.pm
+++ b/lib/App/Spec/Run/Validator.pm
@@ -9,12 +9,12 @@ use List::Util qw/ any /;
 use List::MoreUtils qw/ uniq /;
 use Ref::Util qw/ is_arrayref is_hashref /;
 use Types::Standard qw/ Map Str /;
-use App::Spec::Types qw/ SpecOption SpecParameter /;
+use App::Spec::Types qw/ SpecOption SpecParameter ArgumentValue /;
 use Moo;
 
-has options => ( is => 'ro' );
+has options => ( is => 'ro', isa => Map[Str,ArgumentValue] );
 has option_specs => ( is => 'ro', isa => Map[Str,SpecOption] );
-has parameters => ( is => 'ro' );
+has parameters => ( is => 'ro', isa => Map[Str,ArgumentValue] );
 has param_specs => ( is => 'ro', isa => Map[Str,SpecParameter], required => 1 );
 
 my %validate = (

--- a/lib/App/Spec/Types.pm
+++ b/lib/App/Spec/Types.pm
@@ -1,0 +1,15 @@
+# ABSTRACT: type constraints and coercions
+use strict;
+use warnings;
+package App::Spec::Types;
+use Type::Library -base,
+    -declare => qw(
+                      AppSpec
+              );
+use Type::Utils -all;
+use Types::Standard -types;
+use namespace::clean;
+
+class_type AppSpec, { class => 'App::Spec' };
+
+1;

--- a/lib/App/Spec/Types.pm
+++ b/lib/App/Spec/Types.pm
@@ -7,11 +7,13 @@ use Type::Library -base,
                       AppSpec
                       SpecOption SpecParameter SpecSubcommand
                       RunOutputType
-                      ArgumentType
+                      SpecArgumentCompletion CompletionItem SpecArgumentValues
+                      ArgumentValue ArgumentType
                       RunOutput RunResponse ResponseCallbacks
                       MarkupName
                       PluginName PluginType
                       ValidationErrors
+                      CommandOp
                       EventSubscriber
               );
 use Type::Utils -all;
@@ -25,6 +27,35 @@ class_type SpecParameter, { class => 'App::Spec::Parameter' };
 class_type SpecSubcommand, { class => 'App::Spec::Subcommand' };
 
 enum RunOutputType, [qw( plain data )];
+
+# Str | { replace => 'SELF' } | { replace => [ SHELL_WORDS => Int ] }
+union CompletionItem, [
+    Str,
+    Dict[replace => ( Enum['SELF'] | Tuple[Enum['SHELL_WORDS'],Int] )],
+];
+
+union CommandOp, [Str,CodeRef];
+
+union SpecArgumentCompletion, [
+    Bool,
+    Dict[op => CommandOp],
+    Dict[command => ArrayRef[CompletionItem]],
+    Dict[command_string => Str],
+];
+
+union SpecArgumentValues, [
+    Dict[op => CommandOp],
+    Dict[mapping => HashRef[ArrayRef[Str]|Str|Undef]],
+];
+
+union ArgumentValue, [
+    Undef,
+    Str,
+    ArrayRef[Str],
+    HashRef[Str],
+    HashRef[ArrayRef[Str]],
+];
+
 enum ArgumentType, [qw(string file dir integer flag enum)];
 
 class_type RunOutput, { class => 'App::Spec::Run::Output' };
@@ -44,7 +75,7 @@ declare ValidationErrors, as Dict[
 
 declare EventSubscriber, as Dict[
     plugin => ClassName|Object,
-    method => Defined,
+    method => CommandOp,
 ];
 
 1;

--- a/lib/App/Spec/Types.pm
+++ b/lib/App/Spec/Types.pm
@@ -8,6 +8,7 @@ use Type::Library -base,
                       SpecOption SpecParameter SpecSubcommand
                       RunOutputType
                       ArgumentType
+                      RunOutput RunResponse
                       MarkupName
                       PluginName PluginType
               );
@@ -23,6 +24,10 @@ class_type SpecSubcommand, { class => 'App::Spec::Subcommand' };
 
 enum RunOutputType, [qw( plain data )];
 enum ArgumentType, [qw(string file dir integer flag enum)];
+
+class_type RunOutput, { class => 'App::Spec::Run::Output' };
+class_type RunResponse, { class => 'App::Spec::Run::Response' };
+
 enum MarkupName, [qw(pod swim)];
 
 declare PluginName, as Str,

--- a/lib/App/Spec/Types.pm
+++ b/lib/App/Spec/Types.pm
@@ -5,11 +5,16 @@ package App::Spec::Types;
 use Type::Library -base,
     -declare => qw(
                       AppSpec
+                      SpecOption SpecParameter SpecSubcommand
               );
 use Type::Utils -all;
 use Types::Standard -types;
 use namespace::clean;
 
 class_type AppSpec, { class => 'App::Spec' };
+
+class_type SpecOption, { class => 'App::Spec::Option' };
+class_type SpecParameter, { class => 'App::Spec::Parameter' };
+class_type SpecSubcommand, { class => 'App::Spec::Subcommand' };
 
 1;

--- a/lib/App/Spec/Types.pm
+++ b/lib/App/Spec/Types.pm
@@ -8,9 +8,11 @@ use Type::Library -base,
                       SpecOption SpecParameter SpecSubcommand
                       RunOutputType
                       ArgumentType
-                      RunOutput RunResponse
+                      RunOutput RunResponse ResponseCallbacks
                       MarkupName
                       PluginName PluginType
+                      ValidationErrors
+                      EventSubscriber
               );
 use Type::Utils -all;
 use Types::Standard -types;
@@ -27,11 +29,22 @@ enum ArgumentType, [qw(string file dir integer flag enum)];
 
 class_type RunOutput, { class => 'App::Spec::Run::Output' };
 class_type RunResponse, { class => 'App::Spec::Run::Response' };
+declare ResponseCallbacks, as Map[Str,CodeRef];
 
 enum MarkupName, [qw(pod swim)];
 
 declare PluginName, as Str,
     where { /[A-Z_a-z][0-9A-Z_a-z]*(?:::[0-9A-Z_a-z]+)/ };
 enum PluginType, [qw(Subcommands GlobalOptions)];
+
+declare ValidationErrors, as Dict[
+    parameters => Optional[Map[Str,Str]],
+    options => Optional[Map[Str,Str]],
+];
+
+declare EventSubscriber, as Dict[
+    plugin => ClassName|Object,
+    method => Defined,
+];
 
 1;

--- a/lib/App/Spec/Types.pm
+++ b/lib/App/Spec/Types.pm
@@ -6,6 +6,10 @@ use Type::Library -base,
     -declare => qw(
                       AppSpec
                       SpecOption SpecParameter SpecSubcommand
+                      RunOutputType
+                      ArgumentType
+                      MarkupName
+                      PluginName PluginType
               );
 use Type::Utils -all;
 use Types::Standard -types;
@@ -16,5 +20,13 @@ class_type AppSpec, { class => 'App::Spec' };
 class_type SpecOption, { class => 'App::Spec::Option' };
 class_type SpecParameter, { class => 'App::Spec::Parameter' };
 class_type SpecSubcommand, { class => 'App::Spec::Subcommand' };
+
+enum RunOutputType, [qw( plain data )];
+enum ArgumentType, [qw(string file dir integer flag enum)];
+enum MarkupName, [qw(pod swim)];
+
+declare PluginName, as Str,
+    where { /[A-Z_a-z][0-9A-Z_a-z]*(?:::[0-9A-Z_a-z]+)/ };
+enum PluginType, [qw(Subcommands GlobalOptions)];
 
 1;

--- a/t/13.argv.t
+++ b/t/13.argv.t
@@ -27,7 +27,7 @@ $ENV{PERL5_APPSPECRUN_TEST} = 1;
     my $res1 = $runner1->response;
     my $res2 = $runner2->response;
     # we don't care about the callbacks here
-    $_->callbacks([]) for ($res1, $res2);
+    $_->callbacks({}) for ($res1, $res2);
     cmp_deeply(
         $res1,
         $res2,


### PR DESCRIPTION
(This PR contains the same changes as #15, but organised in a way that should make it much easier to review)

In reference to #14 :
* type constraints everywhere: among other things, this makes clearer what each attribute can accept
* defaults for all attributes where it makes sense
* `BUILDARGS`/`new` instead of `common`/`build`, this makes classes easier to use and extend
* `op` now canonically accepts a coderef (previously it did, but probably by mistake: it's a useful feature, let's support it properly)

Maybe needed before merging:
* documentation for all the type constraints
* better names for them

Possible future work:
* review the various enums
* review the various union types, and check if they really make sense 
* reduce the number of `rw` attributes