### PR TITLE
Add support for float argument type

### DIFF
--- a/lib/App/Spec/Argument.pm
+++ b/lib/App/Spec/Argument.pm
@@ -87,11 +87,13 @@ sub from_dsl {
     if ($dsl =~ s/^=//) {
         # not a flag, default string
         $type = "string";
-        # TODO support all of Getopt::Long types
-        if ($dsl =~ s/^([is])//) {
+        if ($dsl =~ s/^([isf])//) {
             $getopt_type = $1;
             if ($getopt_type eq "i") {
                 $type = "integer";
+            }
+            elsif ($getopt_type eq "f") {
+                $type = "float";
             }
             elsif ($getopt_type eq "s") {
             }
@@ -182,6 +184,8 @@ START INLINE t/data/12.dsl.yaml
       - spec: +req                --Some required flag
       - spec: number=i            --integer option
       - spec: number2|n= +integer --integer option
+      - spec: fnumber=f           --float option
+      - spec: fnumber2|f= +float  --float option
       - spec: date|d=s =today
       - spec: items=s@            --multi option
       - spec: set=s%              --multiple key=value pairs
@@ -212,6 +216,13 @@ START INLINE t/data/12.dsl.yaml
         summary: integer option
         type: integer
         aliases: ["n"]
+      - name: fnumber
+        summary: float option
+        type: float
+      - name: fnumber2
+        summary: float option
+        type: float
+        aliases: ["f"]
       - name: date
         type: string
         default: today

--- a/lib/App/Spec/Run/Validator.pm
+++ b/lib/App/Spec/Run/Validator.pm
@@ -20,6 +20,7 @@ my %validate = (
     file => sub { $_[0] eq '-' or -f $_[0] },
     dir => sub { -d $_[0] },
     integer => sub { $_[0] =~ m/^[+-]?\d+$/ },
+    float => sub { $_[0] =~ m/^[+-]?\d+(?:\.\d+)?$/ },
     flag => sub { 1 },
     enum => sub {
         my ($value, $list) = @_;

--- a/t/data/12.dsl.yaml
+++ b/t/data/12.dsl.yaml
@@ -10,6 +10,8 @@ options:
   - spec: +req                --Some required flag
   - spec: number=i            --integer option
   - spec: number2|n= +integer --integer option
+  - spec: fnumber=f           --float option
+  - spec: fnumber2|f= +float  --float option
   - spec: date|d=s =today
   - spec: items=s@            --multi option
   - spec: set=s%              --multiple key=value pairs
@@ -40,6 +42,13 @@ options:
     summary: integer option
     type: integer
     aliases: ["n"]
+  - name: fnumber
+    summary: float option
+    type: float
+  - name: fnumber2
+    summary: float option
+    type: float
+    aliases: ["f"]
   - name: date
     type: string
     default: today


### PR DESCRIPTION
This patch implements a TODO to support all Getopt::Long types, the only missing one was float.

Done as part of the CPAN Pull Request challenge.