### PR TITLE
Update shebang for bash completions

### DIFF
--- a/lib/App/Spec/Completion/Bash.pm
+++ b/lib/App/Spec/Completion/Bash.pm
@@ -27,7 +27,7 @@ sub generate_completion {
     my $global_options = $spec->options;
     my ($flags_string, $options_string) = $self->flags_options($global_options);
     my $body = <<"EOM";
-#!bash
+#!/usr/bin/env bash
 
 # Generated with perl module App::Spec v$appspec_version
 


### PR DESCRIPTION
Rather than use #!bash use the environment bash to evaluate autocompletion functions. 