### PR TITLE
Set IFS as local variable to prevent changing global env var

### DIFF
--- a/lib/App/Spec/Completion/Bash.pm
+++ b/lib/App/Spec/Completion/Bash.pm
@@ -53,8 +53,9 @@ $completion_outer
 
 _${appname}_compreply() \{
     local prefix=""
+    local IFS=\$'\\n'
     cur="\$(printf '%q' "\$cur")"
-    IFS=\$'\\n' COMPREPLY=(\$(compgen -P "\$prefix" -W "\$*" -- "\$cur"))
+    IFS=\$IFS COMPREPLY=(\$(compgen -P "\$prefix" -W "\$*" -- "\$cur"))
     __ltrim_colon_completions "\$prefix\$cur"
 
     # http://stackoverflow.com/questions/7267185/bash-autocompletion-add-description-for-possible-completions


### PR DESCRIPTION
Resolves:
* https://github.com/perlpunk/shell-completions/issues/2