### PR TITLE
Add a line between the string and line completion for param name

### DIFF
--- a/lib/App/Spec/Completion/Bash.pm
+++ b/lib/App/Spec/Completion/Bash.pm
@@ -448,7 +448,7 @@ EOM
         $function = <<"EOM";
 $function_name() \{
     local CURRENT_WORD="\${words\[\$cword\]\}"
-    local param_$shell_name="\$($string)"
+    local param_$shell_name="\$(\n$string\n)"
     _${appname}_compreply "\$param_$shell_name"
 \}
 EOM

--- a/lib/App/Spec/Completion/Zsh.pm
+++ b/lib/App/Spec/Completion/Zsh.pm
@@ -322,7 +322,7 @@ EOM
 $function_name() \{
     local __dynamic_completion
     local CURRENT_WORD="\$words\[CURRENT\]"
-    IFS=\$'\\n' __dynamic_completion=( \$( $string ) )
+    IFS=\$'\\n' __dynamic_completion=( \$( \n$string\n ) )
     compadd -X "$shell_name:" \$__dynamic_completion
 \}
 EOM


### PR DESCRIPTION
Prevents errors with here-string completion logic issues

I currently create some completion commands with python. See example [here](https://github.com/umccr/cwl-ica-cli/blob/main/autocompletion/bash/cwl-ica.bash)

Using the following syntax

```
python -c  << EOF
<insert python code here>
EOF
```

The _EOF_ must be on its own line.  

I use a sed hack at the moment to get around this.
